### PR TITLE
Support sentiment analysis in multiple languages

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -99,7 +99,7 @@ class BotFrameworkInstrumentation {
             body: {
                 "documents": [
                     {
-                        "language": "en",
+                        "language": session.preferredLocale().substring(0, 2) || "en",
                         "id": this.sentiments.id,
                         "text": text
                     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,7 @@ export class BotFrameworkInstrumentation {
       body: {
         "documents": [
           {
-            "language": "en",
+            "language": session.preferredLocale().substring(0, 2) || "en",
             "id": this.sentiments.id,
             "text": text
           }


### PR DESCRIPTION
At the moment the sentiment analysis is supported in [15 languages ](https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/overview), but `botbuilder-instrumentation` uses English as hardcoded default. 

In think that the right way should be to retrieve the preferredLocale since this should be used to set the language for the current session. However, maybe there should be a setting to override the behaviour via the settings to add a default language?

Only the first two characters are taken from the preferredLocale since the sentiment analysis API only accepts the country code without culture code. (en vs en-us)